### PR TITLE
fix: replace lxml with stdlib and scope deps to feature section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "pixi-ros"
 version = "0.6.1"
 description = "Pixi extension for ROS package management"
 authors = [
-    { name = "Ruben Arts", email = "ruben@prefix.dev" }
+    { name = "Ruben Arts", email = "ruben@prefix.dev" },
+    { name = "Antonio Romano", email = "antonio.romano9900@gmail.com" },
 ]
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requires-python = ">=3.10"
 dependencies = [
     "typer>=0.12.0",
     "tomlkit>=0.12.0",
-    "lxml>=5.0.0",
     "pyyaml>=6.0",
     "py-rattler>=0.6.0",
     "pathspec>=0.11.0",

--- a/src/pixi_ros/init.py
+++ b/src/pixi_ros/init.py
@@ -703,10 +703,43 @@ def _ensure_dependencies(
         }
     )
 
+    # Detect if a [feature.<distro>] section already exists in pixi.toml.
+    # When it does, write workspace deps there instead of [dependencies] so that
+    # they don't bleed into other environments (jazzy, noetic, etc.).
+    use_feature = "feature" in config and distro in config.get("feature", {})
+
+    def _get_deps_table(target_config: dict) -> dict:
+        """Return the right dependencies table based on feature detection."""
+        if use_feature:
+            feature_table = target_config["feature"][distro]
+            if "dependencies" not in feature_table:
+                feature_table["dependencies"] = tomlkit.table()
+            return feature_table["dependencies"]
+        if "dependencies" not in target_config:
+            target_config["dependencies"] = tomlkit.table()
+        return target_config["dependencies"]
+
+    def _get_unix_deps_table(target_config: dict) -> dict:
+        """Return the right [target.unix.dependencies] table based on feature detection."""
+        if use_feature:
+            feature_table = target_config["feature"][distro]
+            if "target" not in feature_table:
+                feature_table["target"] = tomlkit.table()
+            if "unix" not in feature_table["target"]:
+                feature_table["target"]["unix"] = tomlkit.table()
+            if "dependencies" not in feature_table["target"]["unix"]:
+                feature_table["target"]["unix"]["dependencies"] = tomlkit.table()
+            return feature_table["target"]["unix"]["dependencies"]
+        if "target" not in target_config:
+            target_config["target"] = tomlkit.table()
+        if "unix" not in target_config["target"]:
+            target_config["target"]["unix"] = tomlkit.table()
+        if "dependencies" not in target_config["target"]["unix"]:
+            target_config["target"]["unix"]["dependencies"] = tomlkit.table()
+        return target_config["target"]["unix"]["dependencies"]
+
     # Create or get dependencies table
-    if "dependencies" not in config:
-        config["dependencies"] = tomlkit.table()
-    dependencies = config["dependencies"]
+    dependencies = _get_deps_table(config)
 
     # Add base ROS dependencies with comment
     base_deps = {
@@ -790,8 +823,6 @@ def _ensure_dependencies(
                 pkg_name = conda_pkgs[0] if conda_pkgs else ros_pkg
                 dependencies.add(tomlkit.comment(f'{pkg_name} = "*"'))
 
-    config["dependencies"] = dependencies
-
     # Add platform-specific dependencies if multiple mapping platforms
     # First, identify unix dependencies (available on both linux and osx, but not win)
     unix_deps = {}
@@ -822,14 +853,7 @@ def _ensure_dependencies(
 
         # Add unix section if there are unix-specific dependencies
         if unix_deps:
-            if "target" not in config:
-                config["target"] = tomlkit.table()
-            if "unix" not in config["target"]:
-                config["target"]["unix"] = tomlkit.table()
-            if "dependencies" not in config["target"]["unix"]:
-                config["target"]["unix"]["dependencies"] = tomlkit.table()
-
-            target_deps = config["target"]["unix"]["dependencies"]
+            target_deps = _get_unix_deps_table(config)
 
             if len(target_deps) == 0:
                 target_deps.add(

--- a/src/pixi_ros/package_xml.py
+++ b/src/pixi_ros/package_xml.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from lxml import etree
+import xml.etree.ElementTree as etree
 
 
 @dataclass
@@ -59,7 +59,7 @@ class PackageXML:
         try:
             tree = etree.parse(str(path))
             root = tree.getroot()
-        except etree.XMLSyntaxError as e:
+        except etree.ParseError as e:
             raise ValueError(f"Invalid XML in {path}: {e}") from e
 
         # Get format version (defaults to 1 if not specified)


### PR DESCRIPTION
## Summary

- **Replace `lxml` with `xml.etree.ElementTree`**: `lxml` caused an
  `ImportError` when `pixi-ros` is installed as a `pypi-dependency` inside
  a pixi environment, because the wrong shared library was resolved at
  runtime. The stdlib parser handles all well-formed `package.xml` files.

- **Write deps to `[feature.<distro>]` when present**: in multi-environment
  workspaces (e.g. `humble`, `jazzy`, `noetic`, `kilted` all defined as
  features), `pixi-ros init` was writing all resolved dependencies to the
  global `[dependencies]` table, causing them to leak into every other
  environment. The fix detects an existing `[feature.<distro>]` section and
  scopes both `dependencies` and `target.unix.dependencies` inside it.

## Test

Tested end-to-end on macOS (osx-arm64) with a multi-environment
`pixi.toml` using ROS Humble. After running `pixi-ros init --distro humble
--platform osx-arm64`, all workspace dependencies were correctly written to
`[feature.humble.dependencies]` with no bleed into other environments.
Controllers loaded successfully on `ros2 launch`.