### PR TITLE
Fix pixi crash on liblttng-ust-dev

### DIFF
--- a/src/pixi_ros/data/conda-forge.yaml
+++ b/src/pixi_ros/data/conda-forge.yaml
@@ -345,7 +345,10 @@ libhdf5-dev:
 libi2c-dev:
   pixi: [libi2c]
 liblttng-ust-dev:
-  pixi: ["${{ \"lttng-ust\" if linux }}"]
+  pixi:
+    linux: [lttng-ust]
+    osx: []
+    win64: []
 libjpeg:
   pixi: [libjpeg-turbo]
 libjsoncpp:


### PR DESCRIPTION
To reproduce:

```
git clone https://github.com/robosoft-ai/SMACC2
cd SMACC2/
pixi-ros init --distro jazzy --platform linux-64
```

<img width="600" height="228" alt="image" src="https://github.com/user-attachments/assets/d2ff6201-e0c7-48f3-92cd-274e823fd329" />
